### PR TITLE
uv_type: supress `-Werror=unused` compiler errors

### DIFF
--- a/src/uvw/uv_type.hpp
+++ b/src/uvw/uv_type.hpp
@@ -16,7 +16,7 @@ namespace uvw {
  */
 template<typename U>
 struct uv_type {
-    explicit uv_type(loop::token token, std::shared_ptr<loop> ref) noexcept
+    explicit uv_type([[maybe_unused]] loop::token token, std::shared_ptr<loop> ref) noexcept
         : owner{std::move(ref)}, resource{} {}
 
     uv_type(const uv_type &) = delete;


### PR DESCRIPTION
The `uv_type()` constructor does not use its `token` parameter, which causes a `-Werror=unused` compiler error on GCC (and probably on other compilers too).

Luckily, C++17 adds the [`[[maybe_unused]]`][1] attribute that all standards compliant compilers will support to hide unused errors.

[1]: https://en.cppreference.com/w/cpp/language/attributes/maybe_unused

---

This fixes the error reported in https://github.com/skypjack/uvw/issues/294#issuecomment-1683625763, but I didn't want to add a `Fixes: #294` into my commit or PR, since it seems like that issue is more about disabling all potential warnings using CMake.